### PR TITLE
Better error handling

### DIFF
--- a/html/wp-content/themes/jewmich/functions.php
+++ b/html/wp-content/themes/jewmich/functions.php
@@ -69,6 +69,21 @@ add_filter('the_content', function($html) {
 	return $html;
 }, 7);
 
+set_error_handler(function($errno, $errstr, $errfile, $errline) {
+	// handle @
+	if (0 === error_reporting()) {
+		return false;
+	}
+	$message = $errstr . '  at URL ' . $_SERVER['REQUEST_URI'] . ', backtrace: ' . wp_debug_backtrace_summary( null, 1, true );
+	if (WP_DEBUG_DISPLAY || ini_get('display_errors')) {
+		echo '<br />' . $message . '<br />';
+	}
+	if (WP_DEBUG_LOG || ini_get('log_errors')) {
+		error_log($message);
+	}
+	return true;
+}, error_reporting());
+
 // Need to disable the block editor because it conflicts with above
 add_filter('use_block_editor_for_post_type', '__return_false', 6);
 


### PR DESCRIPTION
This uses "set_error_handler()" to add an error handling that logs the
URL in addition to the stack trace, which will help debug PHP warnings
in the logs.